### PR TITLE
Added Config for Pico2 W (rp2350)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,21 @@ endif()
 
 message("Adapter pinout is ${ADAPTER}")
 
-set(PICO_BOARD pico_w)
+
+
+if(NOT (PICO_BOARD MATCHES "pico_w|pico2_w"))
+    message(WARNING "Unknown board '${PICO_BOARD}', using 'pico_w' instead")
+    set(PICO_BOARD pico_w CACHE STRING "Board type")
+    set(PICO_PLATFORM "rp2040")
+elseif(PICO_BOARD STREQUAL pico_w)
+    set(PICO_BOARD pico_w CACHE STRING "Board type")
+    set(PICO_PLATFORM "rp2040")
+elseif(PICO_BOARD STREQUAL "pico2_w")
+    set(PICO_BOARD pico2_w CACHE STRING "Board type")
+    set(PICO_PLATFORM "rp2350")
+endif()
+
+message("PICO_BOARD version is ${PICO_BOARD}")
 
 include(pico_sdk_import.cmake)
 project(PicoAdapterGB C CXX ASM)

--- a/picow/src/main.c
+++ b/picow/src/main.c
@@ -228,7 +228,7 @@ void mobile_validate_relay(){
 // Main and Core1 Loop //
 /////////////////////////
 void main(){
-    speed_240_MHz = set_sys_clock_khz(240000, false);
+//    speed_240_MHz = set_sys_clock_khz(240000, false);
 
     stdio_init_all();
     printf("Booting...\n");

--- a/picow/src/main.c
+++ b/picow/src/main.c
@@ -7,6 +7,7 @@
 
 #include "pico/stdlib.h"
 #include "hardware/pio.h"
+#include "hardware/clocks.h"
 #include "pico/cyw43_arch.h"
 
 #include "globals.h"
@@ -228,7 +229,7 @@ void mobile_validate_relay(){
 // Main and Core1 Loop //
 /////////////////////////
 void main(){
-//    speed_240_MHz = set_sys_clock_khz(240000, false);
+    speed_240_MHz = set_sys_clock_khz(240000, false);
 
     stdio_init_all();
     printf("Booting...\n");


### PR DESCRIPTION
This is a simple PR request to allow to abilty to compile the firmware for either to the pico_w (rp2040) or pico2_w (rp2350).

How to use:
If not board is specified it defaults to pico_w (rp2040)

To specifiy board use `-DPICO_BOARD` (name can be changed if it does not make sense) e.g.

For pico_w:
`cmake -DPICO_BOARD=pico_w . -B build/rp2040`

For pico2_w:
`cmake -DPICO_BOARD=pico2_w . -B build/rp2350`

You can also specify the pin layout (Adapter):
`cmake -DADAPTER=STACKSMASHING -DPICO_BOARD=pico_w . -B build/rp2040`

Notes:

- I used ninja as the cmake generator (`-G Ninja`)
    - `cmake -DADAPTER=STACKSMASHING -DPICO_BOARD=pico2_w . -B build/rp2350 -G Ninja`
- I am unsure how to specify  `PICO_ADAPTER_HARDWARE` from cmake without making a mess, so it will always say "PicoW"
    - Maybe someone with a bit more knowledge in cmake can assist here?
    - The build output name will also need to change based on this.
~~- I had to comment out line 231 from [main.c](https://github.com/zenaro147/PicoAdapterGB/blob/f0cfef4db6eda837e94480f437f5c3599413062f/picow/src/main.c#L231) as it was giving `undefined reference` error which stops the compliation process.~~

How to Test (I'm using Ninja):

On linux: (I haven't tested this yet but should work)

1. `git clone --recurse-submodules https://github.com/Dam-0/PicoAdapterGB`
2. `cd PicoAdapterGB`
3. `cmake -DADAPTER=STACKSMASHING -DPICO_BOARD=pico_w . -B build/rp2040 -G Ninja`
4. `cmake -DADAPTER=STACKSMASHING -DPICO_BOARD=pico2_w . -B build/rp2350 -G Ninja`
5. `ninja -C ./build/rp2040/`
6. `ninja -C ./build/rp2350/`

or a cheeky oneliner:
`git clone --recurse-submodules https://github.com/Dam-0/PicoAdapterGB && cd PicoAdapterGB && cmake -DADAPTER=STACKSMASHING -DPICO_BOARD=pico_w . -B build/rp2040 -G Ninja && cmake -DADAPTER=STACKSMASHING -DPICO_BOARD=pico2_w . -B build/rp2350 -G Ninja && ninja -C ./build/rp2040 && ninja -C ./build/rp2350`

on Windows:
use the [pico vs code extenstion](https://marketplace.visualstudio.com/items?itemName=raspberry-pi.raspberry-pi-pico) to make life easier

you might need to install tools such as `cmake` and `ninja`, i recommend using [chocolatey](https://chocolatey.org/) for this.

1. clone the project via vscode
2. import project via pico extenstion
3. `cmake -DADAPTER=STACKSMASHING -DPICO_BOARD=pico_w . -B build/rp2040 -G Ninja`
4. `ninja.exe -C ./build/rp2040/`



Extra Notes:
everything seems normal, but requires testing while hooked up to a GB, I currently do not have spare parts to test this yet. (tested on pico2_w (rp2350)
![Untitled](https://github.com/user-attachments/assets/10af0925-829d-4b86-b976-9ba53a50808a)
![Screenshot 2024-12-23 110946](https://github.com/user-attachments/assets/081721a5-185e-4e12-ad5b-88593aa630e6)

